### PR TITLE
Include jquery along with jquery-ui in edit_page.html

### DIFF
--- a/pagetree/templates/pagetree/edit_page.html
+++ b/pagetree/templates/pagetree/edit_page.html
@@ -10,7 +10,7 @@
 
 {% block js %}
 
-<link rel="stylesheet" href="http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.3/themes/base/jquery-ui.css" type="text/css" media="all" /> 
+<link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.0/themes/smoothness/jquery-ui.css" />
 
 {% compress css %}
 <style type="text/css">
@@ -25,7 +25,8 @@
 	</style>
 {% endcompress %}
 
-<script src="http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.3/jquery-ui.min.js" type="text/javascript"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.0/jquery-ui.min.js"></script>
 
 {% compress js %}
 <script type="text/javascript">


### PR DESCRIPTION
If we're going to use jquery-ui here, I think we should include jquery as well, instead of expecting it to be there. I just ran into an issue where my site's jquery version was not compatible with this version of jquery-ui. This fixes the issue.
