### PR TITLE
Prevent pagetree's jQuery from interfering with the main app's copy

### DIFF
--- a/pagetree/templates/pagetree/edit_page.html
+++ b/pagetree/templates/pagetree/edit_page.html
@@ -9,7 +9,8 @@
 
 {% block js %}
 
-<link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.0/themes/smoothness/jquery-ui.css" />
+<link rel="stylesheet"
+      href="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/themes/smoothness/jquery-ui.css" />
 
 <style type="text/css">
     .draghandle {
@@ -25,14 +26,24 @@
 	.dragging {background-color: #fee;}
 </style>
 
+<!-- Prevent pagetree's jQuery and jQueryUI from interfering with the
+     main application's copy. -->
+<script>
+    var _pagetree_define_backup = window.define;
+    window.define = undefined;
+</script>
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.0/jquery-ui.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/jquery-ui.min.js"></script>
+<script>
+    var pagetree = { $: jQuery.noConflict(true) };
+    window.define = _pagetree_define_backup;
+</script>
 
 <script type="text/javascript">
 var saveOrderOfChildren = function() {
     var url = "{% url 'reorder-section-children' section.id %}?";
     var worktodo = 0;
-    $("#children-order-list li").each(function(index,element) {
+    pagetree.$("#children-order-list li").each(function(index, element) {
        worktodo = 1;
        var id = $(element).attr('id').split("-")[1];
        url += "section_id_" + index + "=" + id + ";";
@@ -47,7 +58,9 @@ var saveOrderOfChildren = function() {
 var saveOrderOfPageBlocks = function() {
     var url = "{% url 'reorder-pageblocks' section.id %}?";
     var worktodo = 0;
-    $("#edit-blocks-tab>div.block-dragger").each(function(index,element) {
+    pagetree.$("#edit-blocks-tab>div.block-dragger").each(
+        function(index, element
+    ) {
       worktodo = 1;
       var id = $(element).attr('id').split("-")[1];
       url += "pageblock_id_" + index + "=" + id + ";";
@@ -64,8 +77,8 @@ var saveOrderOfPageBlocks = function() {
 </script>
 
 <script type="text/javascript">
-$(function() {
-  $("#children-order-list").sortable({
+pagetree.$(function() {
+  pagetree.$("#children-order-list").sortable({
     containment : 'parent'
     ,axis : 'y'
     ,tolerance: 'pointer'
@@ -73,8 +86,9 @@ $(function() {
     ,handle: '.draghandle'
     ,stop: function (event,ui) { saveOrderOfChildren();}
   });
-  $("#children-order-list").disableSelection();
-  $("#edit-blocks-tab").sortable({
+  pagetree.$("#children-order-list").disableSelection();
+
+  pagetree.$("#edit-blocks-tab").sortable({
     items : 'div.block-dragger'
     ,axis: 'y'
     ,containment: 'parent'
@@ -83,8 +97,7 @@ $(function() {
     ,tolerance: 'pointer'
     ,stop: function (event,ui) { saveOrderOfPageBlocks();}
   });
-
-  $("#edit-blocks-tab").disableSelection();
+  pagetree.$("#edit-blocks-tab").disableSelection();
 });
 </script>
 


### PR DESCRIPTION
Even though pagetree and my django app (worth2) are using the same
version of jQuery, since worth2 is using requirejs it was causing
jquery-ui to not get loaded correctly, breaking the pagetree admin
interface.

This commit loads jQuery in a more cautious way that prevents
interference, in the same way that django-debug-toolbar does it:
    https://github.com/django-debug-toolbar/django-debug-toolbar/blob/69bf1eb127f8c1b6b7c6c2e798ccd208293c1309/debug_toolbar/templates/debug_toolbar/base.html#L7

Also:
- Update jquery-ui to 1.11.2
