### PR TITLE
Add csrf_token to pagetree admin forms

### DIFF
--- a/pagetree/static/pagetree/js/jquery.cookie.js
+++ b/pagetree/static/pagetree/js/jquery.cookie.js
@@ -1,0 +1,117 @@
+/*!
+ * jQuery Cookie Plugin v1.4.1
+ * https://github.com/carhartl/jquery-cookie
+ *
+ * Copyright 2006, 2014 Klaus Hartl
+ * Released under the MIT license
+ */
+(function (factory) {
+	if (typeof define === 'function' && define.amd) {
+		// AMD
+		define(['jquery'], factory);
+	} else if (typeof exports === 'object') {
+		// CommonJS
+		factory(require('jquery'));
+	} else {
+		// Browser globals
+		factory(jQuery);
+	}
+}(function ($) {
+
+	var pluses = /\+/g;
+
+	function encode(s) {
+		return config.raw ? s : encodeURIComponent(s);
+	}
+
+	function decode(s) {
+		return config.raw ? s : decodeURIComponent(s);
+	}
+
+	function stringifyCookieValue(value) {
+		return encode(config.json ? JSON.stringify(value) : String(value));
+	}
+
+	function parseCookieValue(s) {
+		if (s.indexOf('"') === 0) {
+			// This is a quoted cookie as according to RFC2068, unescape...
+			s = s.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+		}
+
+		try {
+			// Replace server-side written pluses with spaces.
+			// If we can't decode the cookie, ignore it, it's unusable.
+			// If we can't parse the cookie, ignore it, it's unusable.
+			s = decodeURIComponent(s.replace(pluses, ' '));
+			return config.json ? JSON.parse(s) : s;
+		} catch(e) {}
+	}
+
+	function read(s, converter) {
+		var value = config.raw ? s : parseCookieValue(s);
+		return $.isFunction(converter) ? converter(value) : value;
+	}
+
+	var config = $.cookie = function (key, value, options) {
+
+		// Write
+
+		if (arguments.length > 1 && !$.isFunction(value)) {
+			options = $.extend({}, config.defaults, options);
+
+			if (typeof options.expires === 'number') {
+				var days = options.expires, t = options.expires = new Date();
+				t.setTime(+t + days * 864e+5);
+			}
+
+			return (document.cookie = [
+				encode(key), '=', stringifyCookieValue(value),
+				options.expires ? '; expires=' + options.expires.toUTCString() : '', // use expires attribute, max-age is not supported by IE
+				options.path    ? '; path=' + options.path : '',
+				options.domain  ? '; domain=' + options.domain : '',
+				options.secure  ? '; secure' : ''
+			].join(''));
+		}
+
+		// Read
+
+		var result = key ? undefined : {};
+
+		// To prevent the for loop in the first place assign an empty array
+		// in case there are no cookies at all. Also prevents odd result when
+		// calling $.cookie().
+		var cookies = document.cookie ? document.cookie.split('; ') : [];
+
+		for (var i = 0, l = cookies.length; i < l; i++) {
+			var parts = cookies[i].split('=');
+			var name = decode(parts.shift());
+			var cookie = parts.join('=');
+
+			if (key && key === name) {
+				// If second argument (value) is a function it's a converter...
+				result = read(cookie, value);
+				break;
+			}
+
+			// Prevent storing a cookie that we couldn't decode.
+			if (!key && (cookie = read(cookie)) !== undefined) {
+				result[name] = cookie;
+			}
+		}
+
+		return result;
+	};
+
+	config.defaults = {};
+
+	$.removeCookie = function (key, options) {
+		if ($.cookie(key) === undefined) {
+			return false;
+		}
+
+		// Must not alter options, thus extending a fresh object...
+		$.cookie(key, '', $.extend({}, options, { expires: -1 }));
+		return !$.cookie(key);
+	};
+
+}));

--- a/pagetree/static/pagetree/js/pagetree-admin.js
+++ b/pagetree/static/pagetree/js/pagetree-admin.js
@@ -1,0 +1,44 @@
+pagetree.getCsrfToken = function() {
+    return pagetree.$.cookie('csrftoken');
+};
+
+pagetree.saveOrderOfChildren = function(url) {
+    var me = this;
+    var worktodo = 0;
+    pagetree.$("#children-order-list li").each(function(index, element) {
+       worktodo = 1;
+       var id = $(element).attr('id').split("-")[1];
+       url += "section_id_" + index + "=" + id + ";";
+    });
+    if (worktodo == 1) {
+        pagetree.$.ajax({
+            type: 'POST',
+            url: url,
+            beforeSend: function(xhr) {
+                xhr.setRequestHeader('X-CSRFToken', me.getCsrfToken());
+            }
+        });
+    }
+};
+
+pagetree.saveOrderOfPageBlocks = function(url) {
+    var me = this;
+    var worktodo = 0;
+    pagetree.$("#edit-blocks-tab>div.block-dragger").each(
+        function(index, element
+    ) {
+      worktodo = 1;
+      var id = $(element).attr('id').split("-")[1];
+      url += "pageblock_id_" + index + "=" + id + ";";
+    });
+    if (worktodo == 1) {
+        /* only bother submitting if there are elements to be sorted */
+        pagetree.$.ajax({
+            type: 'POST',
+            url: url,
+            beforeSend: function(xhr) {
+                xhr.setRequestHeader('X-CSRFToken', me.getCsrfToken());
+            }
+        });
+    }
+};

--- a/pagetree/templates/pagetree/edit_page.html
+++ b/pagetree/templates/pagetree/edit_page.html
@@ -1,6 +1,8 @@
 {% extends "pagetree/base_pagetree.html" %}
 {% load bootstrap %}
 {% load render %}
+{% load static from staticfiles %}
+
 {% block title %}{{section.label}} (edit){% endblock %}
 
 {% block bodyclass %}edit module-{{module.slug}}{% endblock %}
@@ -34,71 +36,42 @@
 </script>
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/jquery-ui.min.js"></script>
+<script src="{% static 'pagetree/js/jquery.cookie.js' %}"></script>
 <script>
     var pagetree = { $: jQuery.noConflict(true) };
     window.define = _pagetree_define_backup;
 </script>
 
-<script type="text/javascript">
-var saveOrderOfChildren = function() {
-    var url = "{% url 'reorder-section-children' section.id %}?";
-    var worktodo = 0;
-    pagetree.$("#children-order-list li").each(function(index, element) {
-       worktodo = 1;
-       var id = $(element).attr('id').split("-")[1];
-       url += "section_id_" + index + "=" + id + ";";
-    });
-    if (worktodo == 1) {
-        var req = new XMLHttpRequest();
-        req.open("POST",url,true);
-        req.send(null);
-    }
-};
-
-var saveOrderOfPageBlocks = function() {
-    var url = "{% url 'reorder-pageblocks' section.id %}?";
-    var worktodo = 0;
-    pagetree.$("#edit-blocks-tab>div.block-dragger").each(
-        function(index, element
-    ) {
-      worktodo = 1;
-      var id = $(element).attr('id').split("-")[1];
-      url += "pageblock_id_" + index + "=" + id + ";";
-    });
-    if (worktodo == 1) {
-        /* only bother submitting if there are elements to be sorted */
-        var req = new XMLHttpRequest();
-        req.open("POST",url,true);
-        req.send(null);
-    }
-
-}
-
-</script>
-
-<script type="text/javascript">
-pagetree.$(function() {
-  pagetree.$("#children-order-list").sortable({
+<script src="{% static 'pagetree/js/pagetree-admin.js' %}"></script>
+<script>
+(function($) {
+  $("#children-order-list").sortable({
     containment : 'parent'
     ,axis : 'y'
     ,tolerance: 'pointer'
     ,activeClass: 'dragging'
     ,handle: '.draghandle'
-    ,stop: function (event,ui) { saveOrderOfChildren();}
+    ,stop: function (event,ui) {
+        pagetree.saveOrderOfChildren(
+            "{% url 'reorder-section-children' section.id %}?");
+    }
   });
-  pagetree.$("#children-order-list").disableSelection();
+  $("#children-order-list").disableSelection();
 
-  pagetree.$("#edit-blocks-tab").sortable({
+  $("#edit-blocks-tab").sortable({
     items : 'div.block-dragger'
     ,axis: 'y'
     ,containment: 'parent'
     ,handle: '.draghandle'
     ,activeClass: 'dragging'
     ,tolerance: 'pointer'
-    ,stop: function (event,ui) { saveOrderOfPageBlocks();}
+    ,stop: function (event,ui) {
+        pagetree.saveOrderOfPageBlocks(
+            "{% url 'reorder-pageblocks' section.id %}?");
+    }
   });
-  pagetree.$("#edit-blocks-tab").disableSelection();
-});
+  $("#edit-blocks-tab").disableSelection();
+})(pagetree.$);
 </script>
 
 {% endblock %}

--- a/pagetree/templates/revert_confirm.html
+++ b/pagetree/templates/revert_confirm.html
@@ -3,6 +3,7 @@
 {% block content %}
 
 <form action="." method="post" class="well">
+    {% csrf_token %}
 
 
 {% if version.more_recent_versions %}


### PR DESCRIPTION
The csrf_token template tag was only present on one of the forms here..
since ccnmtldjango has csrf checking on by default, I think we should include
the csrf_tokens here.

I tested the csrf_token templatetag when the CsrfViewMiddleware is
disabled, and the forms still work.. so if you need to turn it off for
some reason it won't require a change to pagetree.
