### PR TITLE
Fix TypeError when accessing a gated page as an anonymous user

### DIFF
--- a/pagetree/generic/views.py
+++ b/pagetree/generic/views.py
@@ -23,6 +23,7 @@ def edit_page(request, path):
     return pageedit(request, path)
 
 """
+from django.core.exceptions import PermissionDenied
 from django.shortcuts import render
 from django.http import HttpResponseRedirect
 from pagetree.helpers import get_section_from_path
@@ -181,6 +182,9 @@ class PageView(View, SectionMixin):
         return self.gated
 
     def gate_check(self, user):
+        if (not user) or user.is_anonymous():
+            raise PermissionDenied()
+
         if not self.get_gated():
             return None
         # we need to check that they have visited all previous pages


### PR DESCRIPTION
Add a check in the pagetree section's gate_check() method to check for a
valid user. Going through this code as an anonymous user (as
demonstrated in `PageTreeViewTestsLoggedOut` of `ccnmtldjango`) currently
causes this error:

    TypeError at /pages/session-1/
    int() argument must be a string or a number, not 'SimpleLazyObject'

Note that there is an existing user presence check in `pagetree.models.Section.gate_check()`. When first trying to fix this error, I added the `is_anonymous()` check there, but it caused a redirect loop. Instead I've put this in the `Section` view. The check in the `Section` model may no longer be necessary, but I'm not very familiar with this code yet - I'm not sure.