### PR TITLE
Add CSRF token to all post forms

### DIFF
--- a/pagetree/templates/pagetree/edit_page.html
+++ b/pagetree/templates/pagetree/edit_page.html
@@ -201,8 +201,10 @@
 {% endif %}
 
 <form action="{% url 'edit-pageblock' block.id %}" method="post"
-class=""
-      {% if block.edit_form.is_multipart %}enctype="multipart/form-data"{% endif %}>
+      class=""
+      {% if block.edit_form.is_multipart %}
+      enctype="multipart/form-data"
+      {% endif %}>
     {% csrf_token %}
 
 {{ block.default_edit_form|bootstrap }}
@@ -276,12 +278,10 @@ class=""
 <div class="modal-dialog">
       <div class="modal-content">
 <form action="{% url 'add-pageblock' section.id %}"
-
-{% if blocktype.add_form.is_multipart %}
-enctype="multipart/form-data"
-{% endif %}
-      method="post">
-    {% csrf_token %}
+      {% if blocktype.add_form.is_multipart %}
+      enctype="multipart/form-data"
+      {% endif %}
+      method="post">{% csrf_token %}
 
 
   <div class="modal-header">
@@ -315,8 +315,7 @@ enctype="multipart/form-data"
 <div id="edit-page-tab" class="tab-pane">
 
 <form action="{% url 'edit-section' section.id %}" method="post"
-			class="form-horizontal well">
-{% csrf_token %}
+	  class="form-horizontal well">{% csrf_token %}
 <fieldset><legend>Edit Page</legend>
 
 {{ section.edit_form|bootstrap }}

--- a/pagetree/templates/pagetree/page.html
+++ b/pagetree/templates/pagetree/page.html
@@ -51,7 +51,7 @@
 {% if needs_submit %}
 {% if is_submitted %}
 {% else %}
-<form action="." method="post">
+<form action="." method="post">{% csrf_token %}
 {% endif %}
 {% endif %}
 
@@ -70,7 +70,7 @@
 
 {% if is_submitted %}
 {% if allow_redo %}
-<form action="." method="post">
+<form action="." method="post">{% csrf_token %}
 <input type="hidden" name="action" value="reset" />
 <input type="submit" value="clear your answers and try again" class="btn" />
 </form>

--- a/pagetree/templates/pagetree/test_page.html
+++ b/pagetree/templates/pagetree/test_page.html
@@ -50,7 +50,7 @@
 {% if needs_submit %}
 {% if is_submitted %}
 {% else %}
-<form action="." method="post">
+<form action="." method="post">{% csrf_token %}
 {% endif %}
 {% endif %}
 
@@ -69,7 +69,7 @@
 
 {% if is_submitted %}
 {% if allow_redo %}
-<form action="." method="post">
+<form action="." method="post">{% csrf_token %}
 <input type="hidden" name="action" value="reset" />
 <input type="submit" value="clear your answers and try again" class="btn" />
 </form>


### PR DESCRIPTION
I did this same thing on quizblock, but it turns out the template I'm
running into a "CSRF Failed" error on is actually in pagetree.