### PR TITLE
Small UI improvements in the block editor

### DIFF
--- a/pagetree/templates/pagetree/edit_page.html
+++ b/pagetree/templates/pagetree/edit_page.html
@@ -161,25 +161,27 @@
 {% rendersummary block %}
 	</div>
 
-	<div class="col-md-3">
-		<div class="btn-group">
-			<a data-toggle="modal" class="btn btn-default btn-sm"
-			 href="#edit-pageblock-{{block.id}}">
-		<span class="glyphicon glyphicon-edit"></span>
-			edit</a>
+    <div class="col-md-3">
+        <div class="btn-group">
+            <a data-toggle="modal" class="btn btn-default btn-sm"
+               href="#edit-pageblock-{{block.id}}" title="Edit">
+                <span class="glyphicon glyphicon-edit"></span> edit</a>
 
-		<a href="{% url 'delete-pageblock' block.id %}" class="btn
-		btn-danger btn-sm">		<span class="glyphicon glyphicon-trash"></span> delete</a>
+            <a href="{% url 'delete-pageblock' block.id %}"
+               class="btn btn-danger btn-sm" title="Delete">
+                <span class="glyphicon glyphicon-trash"></span></a>
+        </div>
 
-		{% if block.block.exportable %}
-		<a class="btn btn-sm"
-			 rel="tooltip" title="Download JSON dump of this block"
-			 id="export-{{block.id}}"
-			 href="{% url 'export-pageblock-json' block.id %}"><span class="glyphicon glyphicon-download"></span> export</a>
-
-		{% endif %}
-		</div>
-	</div>
+        <div class="btn-group">
+            {% if block.block.exportable %}
+            <a class="btn btn-sm"
+               rel="tooltip" title="Download JSON dump of this block"
+               id="export-{{block.id}}"
+               href="{% url 'export-pageblock-json' block.id %}">
+                <span class="glyphicon glyphicon-download"></span> export</a>
+            {% endif %}
+        </div>
+    </div>
 
 
 </div>


### PR DESCRIPTION
![2015-02-02-134413_189x82_scrot](https://cloud.githubusercontent.com/assets/59292/6006615/e3e65b1c-aae1-11e4-973d-8d35c130f2e3.png)

The large 'delete' button was making me nervous - I think only the trash
can icon is necessary, with the "Delete" text in the title attribute.

I also separated the export button so the edit and delete buttons have
the correct border.