### PR TITLE
Override get_context_data instead of get_extra_context in example

### DIFF
--- a/pagetree/generic/views.py
+++ b/pagetree/generic/views.py
@@ -13,8 +13,8 @@ from pagetree.generic.views import PageView, EditView
 
 
 class MyPageView(PageView):
-    def get_extra_context(self, request, path):
-        ctx = super(MyPageView, self).get_extra_context(request, path)
+    def get_context_data(self, *args, **kwargs):
+        ctx = super(MyPageView, self).get_context_data(*args, **kwargs)
         # Add extra context data
         return ctx
 


### PR DESCRIPTION
In my original PageView example, I was overriding get_extra_context,
which doesn't actually work.