### PR TITLE
Fix get_extra_context override in PageView example

### DIFF
--- a/pagetree/generic/views.py
+++ b/pagetree/generic/views.py
@@ -13,8 +13,8 @@ from pagetree.generic.views import PageView, EditView
 
 
 class MyPageView(PageView):
-    def get_extra_context(self, request, path):
-        ctx = super(MyPageView, self).get_extra_context(request, path)
+    def get_extra_context(self):
+        ctx = super(MyPageView, self).get_extra_context()
         # Add extra context data
         return ctx
 


### PR DESCRIPTION
I was specifying the wrong arguments in my original example.