### PR TITLE
Remove superfluous nav menu from edit section - PMT #99383

### DIFF
--- a/pagetree/templates/pagetree/edit_page.html
+++ b/pagetree/templates/pagetree/edit_page.html
@@ -88,11 +88,6 @@
 
 
 {% block sidenav %}
-<!-- ###### Secondary Navigation ###### -->
-<h3>Sections</h3>
-{% with "/edit" as menu_base %}
-{% include "pagetree/menu.html" %}
-{% endwith %}
 {% endblock %}
 
 {% block navrightextra %}


### PR DESCRIPTION
Jess pointed out that the section navigation is already in the "Hierarchy"
tab of the edit page, and there's no reason to show it twice.