### PR TITLE
Fix for testing pagetree on multiple django versions

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -1,6 +1,7 @@
 """ run tests for pagetree
 
 $ virtualenv ve
+$ ./ve/bin/pip install Django==1.7.5
 $ ./ve/bin/pip install -r test_reqs.txt
 $ ./ve/bin/python runtests.py
 """
@@ -15,6 +16,12 @@ def main():
     # Dynamically configure the Django settings with the minimum necessary to
     # get Django running tests
     settings.configure(
+        MIDDLEWARE_CLASSES=(
+            'django.contrib.sessions.middleware.SessionMiddleware',
+            'django.contrib.auth.middleware.AuthenticationMiddleware',
+            'django.contrib.messages.middleware.MessageMiddleware',
+        ),
+
         INSTALLED_APPS=(
             'django.contrib.auth',
             'django.contrib.contenttypes',

--- a/test_reqs.txt
+++ b/test_reqs.txt
@@ -1,7 +1,6 @@
-Django==1.6.10
 django-treebeard==2.0
 Markdown==2.5.2
-South==1.0.1
+South==1.0.2
 nose==1.3.4
 coverage==3.7.1
 django_nose==1.2


### PR DESCRIPTION
Pagetree was only getting tested with Django 1.6, since the version
specified in test_reqs.txt is 1.6. The solution is to remove Django from test_reqs and
use the version in `.travis.yml`.