### PR TITLE
Remove unnecessary params when calling create_from_dict

### DIFF
--- a/pagetree/tests/test_models.py
+++ b/pagetree/tests/test_models.py
@@ -721,6 +721,15 @@ class SectionTest(TestCase):
         self.user = UserFactory()
         self.section = RootSectionFactory()
 
+    def test_add_pageblock_from_dict(self):
+        self.section.add_pageblock_from_dict({
+            'block_type': 'Test Block',
+            'body': 'test body',
+        })
+        block = self.section.pageblock_set.first()
+        assert(block is not None)
+        self.assertEqual(block.block().body, 'test body')
+
     def test_empty_section_is_unlocked(self):
         self.assertTrue(self.section.unlocked(self.user))
 


### PR DESCRIPTION
It's convenient to define custom pageblocks' create_from_dict method
as passing in the complete dictionary as kwargs on creation. e.g.:

```python
@classmethod
def create_from_dict(cls, d):
    return cls.objects.create(**d)
```

In order for this to work, the basic keys that the dictionary
will contain: `block_type`, `label`, and `css_extra` need to be
removed before calling the custom pageblock's create_from_dict hook.