### PR TITLE
PageBlock as_dict/import_from_dict cascade

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+1.0.9 (2015-03-05)
+==================
+* enable block level import/export that cascades to the content object import/export
+
 1.0.8 (2015-02-27)
 ==================
 * Add Section.unlocked() method

--- a/pagetree/models.py
+++ b/pagetree/models.py
@@ -726,6 +726,14 @@ class PageBlock(models.Model):
         d['block_type'] = self.content_object.display_name
         return d
 
+    def import_from_dict(self, d):
+        self.label = d.get('label', '')
+        self.css_extra = d.get('css_extra', '')
+        self.save()
+
+        if hasattr(self.content_object, 'import_from_dict'):
+            self.content_object.import_from_dict(d)
+
     @classmethod
     def create_from_dict(cls, d):
         return cls.objects.create()
@@ -836,6 +844,10 @@ class TestBlock(models.Model):
 
     def as_dict(self):
         return dict(body=self.body)
+
+    def import_from_dict(self, d):
+        self.body = d.get('body', '')
+        self.save()
 
     def summary_render(self):
         if len(self.body) < 61:

--- a/pagetree/tests/test_models.py
+++ b/pagetree/tests/test_models.py
@@ -423,6 +423,18 @@ class OneLevelWithBlocksTest(unittest.TestCase):
             [p.id for p in self.section1.pageblock_set.all()],
             normal_order)
 
+    def test_import_from_dict(self):
+        b = self.section1.pageblock_set.all()[0]
+        d = {'label': 'new label',
+             'css_extra': 'new css_extra',
+             'body': 'new body'}
+        b.import_from_dict(d)
+        self.assertEquals(b.label, 'new label')
+        self.assertEquals(b.css_extra, 'new css_extra')
+
+        sub = b.block()
+        self.assertEquals(sub.body, 'new body')
+
 
 class UserTrackingTest(unittest.TestCase):
     def setUp(self):

--- a/pagetree/tests/test_views.py
+++ b/pagetree/tests/test_views.py
@@ -2,6 +2,7 @@ from django.test import TestCase
 from django.contrib.auth.models import User
 from django.test.client import Client
 from pagetree.models import Hierarchy, PageBlock
+from json import loads
 
 
 class TestEditViews(TestCase):
@@ -21,7 +22,7 @@ class TestEditViews(TestCase):
                 'slug': 'section-2',
                 'pageblocks': [
                     {'label': 'Welcome to your new Forest Site',
-                     'css_extra': '',
+                     'css_extra': 'the-css-class',
                      'block_type': 'Test Block',
                      'body': 'You should now use the edit link to add content',
                      },
@@ -121,12 +122,17 @@ class TestEditViews(TestCase):
 
     def test_pageblock_json_export(self):
         p = PageBlock.objects.all()[0]
+
         response = self.c.get("/pagetree/pageblock/jsonexport/%d/" % p.id,
                               dict())
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            response.content,
-            '{"body": "You should now use the edit link to add content"}')
+
+        the_json = loads(response.content)
+        self.assertEqual(the_json["body"],
+                         "You should now use the edit link to add content")
+        self.assertEquals(the_json["css_extra"], "the-css-class")
+        self.assertEquals(the_json["block_type"], "Test Block")
+        self.assertEquals(the_json["label"], "Welcome to your new Forest Site")
 
     def test_edit_pageblock(self):
         p = PageBlock.objects.all()[0]

--- a/pagetree/views.py
+++ b/pagetree/views.py
@@ -57,8 +57,8 @@ def delete_pageblock(request, pageblock_id, success_url=None):
 
 def export_pageblock_json(request, pageblock_id):
     block = get_object_or_404(PageBlock, id=pageblock_id)
-    json = dumps(block.block().as_dict())
-    r = HttpResponse(json, content_type="application/json")
+    the_json = dumps(block.as_dict())
+    r = HttpResponse(the_json, content_type="application/json")
     r['Content-Disposition'] = ('attachment; filename=pageblock_%d.json'
                                 % int(pageblock_id))
     return r
@@ -73,7 +73,7 @@ def import_pageblock_json(request, pageblock_id):
         if 'file' not in request.FILES:
             return HttpResponse("you must upload a json file")
         json = loads(request.FILES['file'].read())
-        block.block().import_from_dict(json)
+        block.import_from_dict(json)
         return HttpResponseRedirect(block.section.get_edit_url())
     else:
         return render_to_response("import_json.html", dict(),

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ from setuptools import setup
 
 setup(
     name="django-pagetree",
-    version="1.0.8",
+    version="1.0.9",
     author="Anders Pearson",
     author_email="anders@columbia.edu",
     url="https://github.com/ccnmtl/django-pagetree",


### PR DESCRIPTION
Allow extra_css and label to be exported from PageBlock, as well as the content object's attributes
* enable block level import_from_dict/as_dict that cascades to the content object import_from_dict/as_dict
