### PR TITLE
Use django-bootstrap3's form renderer instead of django-bootstrap-form

### DIFF
--- a/pagetree/templates/pagetree/edit_page.html
+++ b/pagetree/templates/pagetree/edit_page.html
@@ -1,5 +1,5 @@
 {% extends "pagetree/base_pagetree.html" %}
-{% load bootstrap %}
+{% load bootstrap3 %}
 {% load render %}
 {% load static from staticfiles %}
 
@@ -208,9 +208,9 @@
                           {% endif %}>
                         {% csrf_token %}
 
-                        {{ block.default_edit_form|bootstrap }}
+                        {% bootstrap_form block.default_edit_form %}
                         {% with block.edit_form as ef %}
-                        {{ ef|bootstrap }}
+                        {% bootstrap_form ef %}
                         {% if ef.alt_text %}
                         <div>{{ ef.alt_text|safe }}</div>
                         {% endif %}
@@ -255,7 +255,7 @@
           class="well form-inline">
         {% csrf_token %}
 
-        {{ section.add_child_section_form|bootstrap }}
+        {% bootstrap_form section.add_child_section_form layout='inline' %}
 
         <input type="submit" value="add child section" class="btn btn-primary"
                />
@@ -293,8 +293,8 @@
                         <fieldset>
                             <input type="hidden" name="blocktype" value="{{blocktype.display_name}}"/>
 
-                            {{section.add_pageblock_form|bootstrap}}
-                            {{blocktype.add_form|bootstrap}}
+                            {% bootstrap_form section.add_pageblock_form %}
+                            {% bootstrap_form blocktype.add_form %}
 
                         </fieldset>
 
@@ -319,7 +319,7 @@
           class="form-horizontal well">{% csrf_token %}
         <fieldset><legend>Edit Page</legend>
 
-            {{ section.edit_form|bootstrap }}
+            {% bootstrap_form section.edit_form layout='horizontal' %}
 
             <input type="submit" value="save" class="btn btn-primary" />
         </fieldset>

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         "coverage",
         "django_nose",
         "django-markwhat",
+        "django-bootstrap3",
         ],
     scripts=[],
     license="BSD",


### PR DESCRIPTION
The django-bootstrap3 package has a better-maintained set of form rendering tags than django-bootstrap-form (http://django-bootstrap3.readthedocs.org/en/latest/templatetags.html).

This fixes this alignment problem in the Add Child form:
![2015-03-10-161339_386x135_scrot](https://cloud.githubusercontent.com/assets/59292/6584383/3bf70132-c741-11e4-94fd-860cfe8ef793.png)

using django-bootstrap3's templatetag:
![2015-03-10-161313_391x131_scrot](https://cloud.githubusercontent.com/assets/59292/6584384/3eb33026-c741-11e4-9436-3e55ae2fb386.png)