### PR TITLE
Add BasePageBlock and move TestBlock to test_models.py

### DIFF
--- a/pagetree/__init__.py
+++ b/pagetree/__init__.py
@@ -1,0 +1,3 @@
+# This is required for south's syncdb to pick up TestBlock in
+# Django 1.6
+from pagetree.test_models import *

--- a/pagetree/generic/models.py
+++ b/pagetree/generic/models.py
@@ -1,0 +1,116 @@
+from django import forms
+from django.db import models
+try:
+    from django.contrib.contenttypes.fields import GenericRelation
+except ImportError:
+    # Old location for django 1.6
+    from django.contrib.contenttypes.generic import GenericRelation
+
+from pagetree.models import Hierarchy, UserPageVisit, PageBlock
+
+
+class BasePageBlock(models.Model):
+    """An abstract pageblock to be used for custom pageblocks."""
+
+    class Meta:
+        abstract = True
+
+    display_name = 'Unimplemented BasePageBlock'
+    pageblocks = GenericRelation(PageBlock)
+
+    def needs_submit(self):
+        """Determines whether this pageblock needs form controls rendered.
+
+        If needs_submit is True, then pagetree will create a <form>
+        on this pageblock's surrounding page, and a Submit button for
+        that form. It may also render a "Clear results" button, under
+        the right circumstances. The surrounding <form> allows pagetree
+        to handle form submissions for multiple blocks on the same page.
+
+        Also, when needs_submit is True, the POST data on the Section's
+        submit() step gets processed, but when needs_submit is False,
+        nothing is sent to the server.
+
+        :returns: a boolean
+        """
+
+        return False
+
+    def unlocked(self, user):
+        """Determines whether the user can proceed past this block.
+
+        The current user is passed in to this function, allowing you to,
+        for example, find out if that user has submitted the info
+        necessary to proceed past this block's page.
+
+        :param user: the current user
+        :returns: a boolean
+        """
+
+        return True
+
+    def submit(self, user, request_data):
+        """Handle this pageblock's form submission.
+
+        :returns: None
+        """
+
+        pass
+
+    def redirect_to_self_on_submit(self):
+        """Determines where the user is redirected to on page submission.
+
+        If submit returns True, then the user will be redirected to the
+        next page in the hierarchy. Otherwise, they be redirected to the
+        current page.
+
+        :returns: a boolean
+        """
+
+        return True
+
+    def clear_user_submissions(self, user):
+        """A hook to clear any user submissions for this block.
+
+        :returns: None
+        """
+
+        pass
+
+    def pageblock(self):
+        return self.pageblocks.first()
+
+    # TODO: I'd like to have all the following methods be inherited
+    # somehow. For now these need to be copy and pasted for each custom
+    # pageblock.
+    @staticmethod
+    def add_form():
+        return BasePageBlockForm()
+
+    def edit_form(self):
+        return BasePageBlockForm(instance=self)
+
+    @staticmethod
+    def create(request):
+        form = BasePageBlockForm(request.POST)
+        return form.save()
+
+    @classmethod
+    def create_from_dict(cls, d):
+        return cls.objects.create(**d)
+
+    def edit(self, vals, files):
+        form = BasePageBlockForm(data=vals, files=files, instance=self)
+        if form.is_valid():
+            form.save()
+
+
+class BasePageBlockForm(forms.ModelForm):
+    """Example ModelForm for the BasePageBlock.
+
+    This is just an example. It should always be replaced with your
+    own ModelForm pointing to the custom pageblock.
+    """
+
+    class Meta:
+        model = BasePageBlock

--- a/pagetree/models.py
+++ b/pagetree/models.py
@@ -14,6 +14,7 @@ from json import dumps
 from treebeard.mp_tree import MP_Node
 import django.core.exceptions
 from treebeard.forms import MoveNodeForm
+
 from pagetree.reports import ReportableInterface, ReportColumnInterface
 
 
@@ -782,83 +783,3 @@ class Version(models.Model):
                 versions.append(v)
         versions.sort(lambda a, b: cmp(b.saved_at, a.saved_at))
         return versions
-
-
-class TestReportColumn(ReportColumnInterface):
-
-    def identifier(self):
-        return "Test Report Column"
-
-    def metadata(self):
-        return ['', self.identifier(), "generic",
-                "string", "this is a test"]
-
-    def user_value(self, user):
-        return user.username
-
-
-class TestBlock(models.Model):
-    """ this is a pageblock that is exclusively for pagetree's
-    internal tests so we have some kind of block to test with
-    without having to pull in the whole django-pageblocks
-    package and its dependencies.
-
-    You should never use it. In fact, forget that you ever saw this.
-    """
-    pageblocks = generic.GenericRelation(PageBlock)
-    body = models.TextField(blank=True)
-
-    template_file = "pagetree/testblock.html"
-    display_name = "Test Block"
-
-    def __unicode__(self):
-        return unicode(self.pageblock())
-
-    def pageblock(self):
-        return self.pageblocks.first()
-
-    @classmethod
-    def add_form(cls):
-        class AddForm(forms.Form):
-            body = forms.CharField(
-                widget=forms.widgets.Textarea(attrs={'cols': 80}))
-        return AddForm()
-
-    @classmethod
-    def create(cls, request):
-        return TestBlock.objects.create(body=request.POST.get('body', ''))
-
-    @classmethod
-    def create_from_dict(cls, d):
-        return cls.objects.create(**d)
-
-    def edit_form(self):
-        class EditForm(forms.Form):
-            body = forms.CharField(widget=forms.widgets.Textarea(),
-                                   initial=self.body)
-        return EditForm()
-
-    def edit(self, vals, files):
-        self.body = vals.get('body', '')
-        self.save()
-
-    def as_dict(self):
-        return dict(body=self.body)
-
-    def import_from_dict(self, d):
-        self.body = d.get('body', '')
-        self.save()
-
-    def summary_render(self):
-        if len(self.body) < 61:
-            return self.body
-        else:
-            return self.body[:61] + "..."
-
-    def report_metadata(self):
-        return [TestReportColumn()]
-
-    def report_values(self):
-        return [TestReportColumn()]
-
-ReportableInterface.register(TestBlock)

--- a/pagetree/test_models.py
+++ b/pagetree/test_models.py
@@ -1,0 +1,90 @@
+from django import forms
+from django.db import models
+from django.contrib.contenttypes import generic
+
+from pagetree.generic.models import BasePageBlock
+from pagetree.models import PageBlock
+from pagetree.reports import ReportableInterface, ReportColumnInterface
+
+
+class TestReportColumn(ReportColumnInterface):
+
+    def identifier(self):
+        return "Test Report Column"
+
+    def metadata(self):
+        return ['', self.identifier(), "generic",
+                "string", "this is a test"]
+
+    def user_value(self, user):
+        return user.username
+
+
+class TestBlock(BasePageBlock):
+    """ this is a pageblock that is exclusively for pagetree's
+    internal tests so we have some kind of block to test with
+    without having to pull in the whole django-pageblocks
+    package and its dependencies.
+
+    You should never use it. In fact, forget that you ever saw this.
+    """
+
+    class Meta:
+        app_label = 'pagetree'
+
+    body = models.TextField(blank=True)
+
+    template_file = "pagetree/testblock.html"
+    display_name = "Test Block"
+
+    def __unicode__(self):
+        return unicode(self.pageblock())
+
+    def pageblock(self):
+        return self.pageblocks.first()
+
+    @classmethod
+    def add_form(cls):
+        class AddForm(forms.Form):
+            body = forms.CharField(
+                widget=forms.widgets.Textarea(attrs={'cols': 80}))
+        return AddForm()
+
+    @classmethod
+    def create(cls, request):
+        return TestBlock.objects.create(body=request.POST.get('body', ''))
+
+    @classmethod
+    def create_from_dict(cls, d):
+        return cls.objects.create(**d)
+
+    def edit_form(self):
+        class EditForm(forms.Form):
+            body = forms.CharField(widget=forms.widgets.Textarea(),
+                                   initial=self.body)
+        return EditForm()
+
+    def edit(self, vals, files):
+        self.body = vals.get('body', '')
+        self.save()
+
+    def as_dict(self):
+        return dict(body=self.body)
+
+    def import_from_dict(self, d):
+        self.body = d.get('body', '')
+        self.save()
+
+    def summary_render(self):
+        if len(self.body) < 61:
+            return self.body
+        else:
+            return self.body[:61] + "..."
+
+    def report_metadata(self):
+        return [TestReportColumn()]
+
+    def report_values(self):
+        return [TestReportColumn()]
+
+ReportableInterface.register(TestBlock)

--- a/pagetree/tests/factories.py
+++ b/pagetree/tests/factories.py
@@ -1,6 +1,7 @@
 from django.contrib.auth.models import User
 from django.test.testcases import TestCase
-from pagetree.models import Hierarchy, Section, TestBlock
+from pagetree.models import Hierarchy, Section
+from pagetree.test_models import TestBlock
 import factory
 
 


### PR DESCRIPTION
I moved TestBlock outside models.py mainly so I could inherit BasePageBlock
from it, so that code gets tested. I think it makes more sense to have the
TestBlock in a different file than the actual pagetree models anyways.