### PR TITLE
Fix sphinx conf for readthedocs.org

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,7 +41,7 @@ extensions = [
 templates_path = ['_templates']
 
 # The suffix(es) of source filenames.
-source_suffix = ['.rst']
+source_suffix = '.rst'
 
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'


### PR DESCRIPTION
Sphinx 1.2.2 that's on readthedocs.org doesn't allow the conf's
source_suffix to be a list. I created the conf with Sphinx 1.3.

This change will hopefully fix the build error here:
https://readthedocs.org/builds/django-pagetree/2432598/

    /site-packages/sphinx/util/__init__.py", line 94, in get_matching_docs
        suffixpattern = '*' + suffix
        TypeError: cannot concatenate 'str' and 'list' objects