### PR TITLE
Use 'default' theme for readthedocs.org compatibility

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -112,7 +112,7 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'alabaster'
+html_theme = 'default'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
The default 'alabaster' theme isn't in sphinx 1.2.2 on readthedocs.org:
https://readthedocs.org/builds/django-pagetree/2449340/