### PR TITLE
Make selected hierarchy section more obvious

### DIFF
--- a/pagetree/templates/pagetree/edit_page.html
+++ b/pagetree/templates/pagetree/edit_page.html
@@ -120,9 +120,14 @@
             <ul>
                 {% for s in root.get_descendants %}
                 <li class="menu" style="list-style: none; line-height: 150%">
+                    {% ifequal s section %}
+                    <span class="glyphicon glyphicon-hand-right"></span>
+                    <strong>
+                    {% endifequal %}
                     <a href="{{s.get_edit_url}}"
                        >{{s.label}}</a>
                     {% ifequal s section %}
+                    </strong>
                     <span class="glyphicon glyphicon-hand-left"></span>
                     {% endifequal %}
                     {% if s.get_children %}


### PR DESCRIPTION
I added bold text and an extra icon here to make it clearer where you
are in the hierarchy.

![2015-03-31-112200_299x118_scrot](https://cloud.githubusercontent.com/assets/59292/6922344/6fbf5b92-d798-11e4-9956-415ad65fd521.png)
