### PR TITLE
Fix bug where cached value wasn't used when value was 0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+1.1.3
+==================
+* Fixed a bug that prevented cached values from getting used,
+  if the value was 0.
+
 1.1.2 (2015-04-22)
 ==================
 * Add confirmation page when deleting a pageblock.

--- a/pagetree/models.py
+++ b/pagetree/models.py
@@ -217,7 +217,7 @@ class Section(MP_Node):
     def is_last_child(self):
         key = "pagetree.%d.is_last_child" % self.id
         v = cache.get(key)
-        if v:
+        if v is not None:
             statsd.incr("pagetree.is_last_child.cache_hit")
             return v
         statsd.incr("pagetree.is_last_child.cache_miss")
@@ -287,7 +287,7 @@ class Section(MP_Node):
     def get_absolute_url(self):
         key = "pagetree.%d.get_absolute_url" % self.id
         v = cache.get(key)
-        if v:
+        if v is not None:
             statsd.incr("pagetree.get_absolute_url.cache_hit")
             return v
         statsd.incr("pagetree.get_absolute_url.cache_miss")
@@ -307,7 +307,7 @@ class Section(MP_Node):
     def get_edit_url(self):
         key = "pagetree.%d.get_edit_url" % self.id
         v = cache.get(key)
-        if v:
+        if v is not None:
             statsd.incr("pagetree.get_edit_url.cache_hit")
             return v
         statsd.incr("pagetree.get_edit_url.cache_miss")


### PR DESCRIPTION
When debugging the `is_last_child` cache, I saw the value
of cache.get() here is either 1, 0, or None if the cached
value isn't present. Currently, only values of 1 are getting
used, because if the value is 0, the `if v:` to check if
the cache is present fails. I think we need to be more
specific here and do: `if v is not None:`

This change improved performance a little bit in my local testing
with memcached, but it's still not great: Calling the cache for
each node in the tree takes time, and it would be great to find
a way to interact with the cache just once for the pagetree edit
page.

refs #63