### PR TITLE
Fix Edit Page Display

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,12 @@
+1.1.4 (2015-05-13)
+==================
+* Show sections with empty labels in the edit_page hierarchy
+
 1.1.3 (2015-05-04)
 ==================
 * Fixed a bug that prevented cached values from getting used,
   if the value was 0.
+
 
 1.1.2 (2015-04-22)
 ==================

--- a/pagetree/templates/pagetree/edit_page.html
+++ b/pagetree/templates/pagetree/edit_page.html
@@ -125,7 +125,7 @@
                     <strong>
                     {% endifequal %}
                     <a href="{{s.get_edit_url}}"
-                       >{{s.label}}</a>
+                       >{{s.label|default:"Empty Label"}}{% if s.label|length < 1 %} ({{s.slug}}){% endif %}</a>
                     {% ifequal s section %}
                     </strong>
                     <span class="glyphicon glyphicon-hand-left"></span>

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ from setuptools import setup
 
 setup(
     name="django-pagetree",
-    version="1.1.3",
+    version="1.1.4",
     author="Anders Pearson",
     author_email="anders@columbia.edu",
     url="https://github.com/ccnmtl/django-pagetree",


### PR DESCRIPTION
Sections with empty labels do not display properly in the edit page hierarchy. Provide a custom display.