### PR TITLE
Markup changes in page.html

### DIFF
--- a/pagetree/templates/pagetree/page.html
+++ b/pagetree/templates/pagetree/page.html
@@ -25,7 +25,9 @@
 
 <ul class="nav navbar-nav">
   {% for section in modules %}
-  <li{% ifequal section.id module.id %} class="active"{% endifequal %}><a href="{{section.get_absolute_url}}">{{section.label}}</a></li>
+  <li {% if section.id == module.id %}class="active"{% endif %}>
+      <a href="{{section.get_absolute_url}}">{{section.label}}</a>
+  </li>
   {% endfor %}
 </ul>
 
@@ -33,7 +35,7 @@
 
 {% block navrightextra %}
 {% if not request.user.is_anonymous %}
-<li><a href="{{section.get_edit_url}}" class="btn btn-success">edit page</a></li>
+<a href="{{section.get_edit_url}}" class="btn btn-success">edit page</a>
 {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
* I took the edit page link out of the `<li>` tag, since it's not
  valid html to have an `<li>` tag outside of a `<ul>` element, and
  we don't need it anyways.
* Cleaned up some formatting for the navbar `<ul>`.