### PR TITLE
Remove 'label' class from the pageblock count

### DIFF
--- a/pagetree/templates/pagetree/edit_page.html
+++ b/pagetree/templates/pagetree/edit_page.html
@@ -148,7 +148,7 @@
                     <strong>
                     {% endifequal %}
                         <span title="The number of pageblocks in this section"
-                              class="pagetree-pageblock-section-count label">
+                              class="pagetree-pageblock-section-count">
                             {{s.pageblock_set.count}}
                         </span>
                         &nbsp;&nbsp;


### PR DESCRIPTION
This class causes bootstrap to render the text as white,
and we're not using it anyways, so I removed it.