### PR TITLE
Remove duplicate queries when calling PageBlock.block()

### DIFF
--- a/pagetree/generic/views.py
+++ b/pagetree/generic/views.py
@@ -45,10 +45,12 @@ from pagetree.models import CloneHierarchyForm, Hierarchy
 
 
 def has_responses(section):
-    quizzes = [p.block() for p in section.pageblock_set.all()
-               if hasattr(p.block(), 'needs_submit') and
-               p.block().needs_submit()]
-    return quizzes != []
+    for p in section.pageblock_set.all():
+        block = p.block()
+        if hasattr(block, 'needs_submit') and block.needs_submit():
+            return True
+
+    return False
 
 
 def visit_root(section, fallback_url="/admin/"):
@@ -276,9 +278,12 @@ def generic_instructor_page(request, path, hierarchy="main",
     section = get_section_from_path(path, hierarchy=hierarchy)
     root = section.hierarchy.get_root()
 
-    quizzes = [p.block() for p in section.pageblock_set.all()
-               if hasattr(p.block(), 'needs_submit') and
-               p.block().needs_submit()]
+    quizzes = []
+    for p in section.pageblock_set.all():
+        block = p.block()
+        if hasattr(block, 'needs_submit') and block.needs_submit():
+            return quizzes.append(block)
+
     context = dict(section=section,
                    quizzes=quizzes,
                    module=section.get_module(),
@@ -307,9 +312,12 @@ class InstructorView(SectionMixin, TemplateView):
         section = self.get_section(path)
         root = section.hierarchy.get_root()
 
-        quizzes = [p.block() for p in section.pageblock_set.all()
-                   if hasattr(p.block(), 'needs_submit') and
-                   p.block().needs_submit()]
+        quizzes = []
+        for p in section.pageblock_set.all():
+            block = p.block()
+            if hasattr(block, 'needs_submit') and block.needs_submit():
+                return quizzes.append(block)
+
         context = dict(section=section,
                        quizzes=quizzes,
                        module=section.get_module(),

--- a/pagetree/views.py
+++ b/pagetree/views.py
@@ -200,8 +200,9 @@ def exporter(request):
         protocol = "https"
     url_base = protocol + "//" + request.get_host()
     for pb in PageBlock.objects.filter(section__hierarchy=h):
-        if hasattr(pb.block(), 'list_resources'):
-            for r in pb.block().list_resources():
+        block = pb.block()
+        if hasattr(block, 'list_resources'):
+            for r in block.list_resources():
                 resources.append(url_base + r)
     data['resources'] = resources
     resp = HttpResponse(dumps(data))


### PR DESCRIPTION
Because PageBlock.block() returns a ForeignKey, it results in
a query to the database.