### PR TITLE
Use 'pageblock' instead of 'block' as django template var

### DIFF
--- a/pagetree/models.py
+++ b/pagetree/models.py
@@ -701,7 +701,8 @@ class PageBlock(models.Model):
         if hasattr(self.content_object, "template_file"):
             t = get_template(getattr(self.content_object, "template_file"))
             d = kwargs
-            d['block'] = self.content_object
+            d['pageblock'] = self.content_object
+            d['block'] = d['pageblock']
             c = Context(d)
             return t.render(c)
         else:

--- a/pagetree/templates/pagetree/edit_page.html
+++ b/pagetree/templates/pagetree/edit_page.html
@@ -179,39 +179,39 @@
 
     <p>Drag the <span class="glyphicon glyphicon-resize-vertical"></span> arrows to reorder pageblocks:</p>
 
-    {% for block in section.pageblock_set.all %}
-    <div class="row block-dragger" id="pageblock-{{block.id}}">
+    {% for pageblock in section.pageblock_set.all %}
+    <div class="row block-dragger" id="pageblock-{{pageblock.id}}">
 
         <div class="col-md-1 draghandle">
             <span class="glyphicon glyphicon-resize-vertical"></span>
         </div>
 
         <div class="col-md-2">
-            <b><a data-toggle="modal" href="#edit-pageblock-{{block.id}}">{{block.block.display_name}}</a></b>
+            <b><a data-toggle="modal" href="#edit-pageblock-{{pageblock.id}}">{{pageblock.block.display_name}}</a></b>
         </div>
 
         <div class="col-md-6">
-            <a data-toggle="modal" href="#edit-pageblock-{{block.id}}">{{block.label}}</a>
-            {% rendersummary block %}
+            <a data-toggle="modal" href="#edit-pageblock-{{pageblock.id}}">{{pageblock.label}}</a>
+            {% rendersummary pageblock %}
         </div>
 
         <div class="col-md-3">
             <div class="btn-group">
                 <a data-toggle="modal" class="btn btn-default btn-sm"
-                   href="#edit-pageblock-{{block.id}}" title="Edit">
+                   href="#edit-pageblock-{{pageblock.id}}" title="Edit">
                     <span class="glyphicon glyphicon-edit"></span> edit</a>
 
-                <a href="{% url 'delete-pageblock' block.id %}"
+                <a href="{% url 'delete-pageblock' pageblock.id %}"
                    class="btn btn-danger btn-sm" title="Delete">
                     <span class="glyphicon glyphicon-trash"></span></a>
             </div>
 
             <div class="btn-group">
-                {% if block.block.exportable %}
+                {% if pageblock.block.exportable %}
                 <a class="btn btn-sm"
                    rel="tooltip" title="Download JSON dump of this block"
-                   id="export-{{block.id}}"
-                   href="{% url 'export-pageblock-json' block.id %}">
+                   id="export-{{pageblock.id}}"
+                   href="{% url 'export-pageblock-json' pageblock.id %}">
                     <span class="glyphicon glyphicon-download"></span> export</a>
                 {% endif %}
             </div>
@@ -222,29 +222,29 @@
     {% endfor %}
 
 
-    {% for block in section.pageblock_set.all %}
-    <div class="modal fade block-edit" id="edit-pageblock-{{block.id}}" role="dialog">
+    {% for pageblock in section.pageblock_set.all %}
+    <div class="modal fade block-edit" id="edit-pageblock-{{pageblock.id}}" role="dialog">
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal">×</button>
-                    <h3>Edit {{block.block.display_name}}</h3>
+                    <h3>Edit {{pageblock.block.display_name}}</h3>
                 </div>
                 <div class="modal-body">
 
-                    {% if block.block.importable %}
-                    <a href="{% url 'import-pageblock-json' block.id %}">import json</a>
+                    {% if pageblock.block.importable %}
+                    <a href="{% url 'import-pageblock-json' pageblock.id %}">import json</a>
                     {% endif %}
 
-                    <form action="{% url 'edit-pageblock' block.id %}" method="post"
+                    <form action="{% url 'edit-pageblock' pageblock.id %}" method="post"
                           class=""
-                          {% if block.edit_form.is_multipart %}
+                          {% if pageblock.edit_form.is_multipart %}
                           enctype="multipart/form-data"
                           {% endif %}>
                         {% csrf_token %}
 
-                        {{ block.default_edit_form|bootstrap }}
-                        {% with block.edit_form as ef %}
+                        {{ pageblock.default_edit_form|bootstrap }}
+                        {% with pageblock.edit_form as ef %}
                         {{ ef|bootstrap }}
                         {% if ef.alt_text %}
                         <div>{{ ef.alt_text|safe }}</div>

--- a/pagetree/templates/pagetree/edit_page.html
+++ b/pagetree/templates/pagetree/edit_page.html
@@ -180,6 +180,7 @@
     <p>Drag the <span class="glyphicon glyphicon-resize-vertical"></span> arrows to reorder pageblocks:</p>
 
     {% for pageblock in section.pageblock_set.all %}
+    {% with block=pageblock %}
     <div class="row block-dragger" id="pageblock-{{pageblock.id}}">
 
         <div class="col-md-1 draghandle">
@@ -219,10 +220,12 @@
 
 
     </div>
+    {% endwith %}
     {% endfor %}
 
 
     {% for pageblock in section.pageblock_set.all %}
+    {% with block=pageblock %}
     <div class="modal fade block-edit" id="edit-pageblock-{{pageblock.id}}" role="dialog">
         <div class="modal-dialog">
             <div class="modal-content">
@@ -261,6 +264,7 @@
                 </form>
         </div></div>
     </div>
+    {% endwith %}
     {% endfor %}
 
     {% else %}

--- a/pagetree/templates/pagetree/page.html
+++ b/pagetree/templates/pagetree/page.html
@@ -3,13 +3,17 @@
 
 {% block js %}
 {% for pageblock in section.pageblock_set.all %}
+{% with block=pageblock %}
 {% renderjs pageblock %}
+{% endwith %}
 {% endfor %}
 {% endblock %}
 
 {% block css %}
 {% for pageblock in section.pageblock_set.all %}
+{% with block=pageblock %}
 {% rendercss pageblock %}
+{% endwith %}
 {% endfor %}
 {% endblock %}
 
@@ -59,10 +63,12 @@
 
 
 {% for pageblock in section.pageblock_set.all %}
+{% with block=pageblock %}
 <div class="pageblock{% if pageblock.css_extra %} {{pageblock.css_extra}}{% endif %}">
 {% if pageblock.label %}<h3>{{pageblock.label}}</h3>{% endif %}
 {% render pageblock %}
 </div>
+{% endwith %}
 {% endfor %}
 
 

--- a/pagetree/templates/pagetree/page.html
+++ b/pagetree/templates/pagetree/page.html
@@ -2,14 +2,14 @@
 {% load render %}
 
 {% block js %}
-{% for block in section.pageblock_set.all %}
-{% renderjs block %}
+{% for pageblock in section.pageblock_set.all %}
+{% renderjs pageblock %}
 {% endfor %}
 {% endblock %}
 
 {% block css %}
-{% for block in section.pageblock_set.all %}
-{% rendercss block %}
+{% for pageblock in section.pageblock_set.all %}
+{% rendercss pageblock %}
 {% endfor %}
 {% endblock %}
 
@@ -58,10 +58,10 @@
 {% endif %}
 
 
-{% for block in section.pageblock_set.all %}
-<div class="pageblock{% if block.css_extra %} {{block.css_extra}}{% endif %}">
-{% if block.label %}<h3>{{block.label}}</h3>{% endif %}
-{% render block %}
+{% for pageblock in section.pageblock_set.all %}
+<div class="pageblock{% if pageblock.css_extra %} {{pageblock.css_extra}}{% endif %}">
+{% if pageblock.label %}<h3>{{pageblock.label}}</h3>{% endif %}
+{% render pageblock %}
 </div>
 {% endfor %}
 

--- a/pagetree/templates/pagetree/test_page.html
+++ b/pagetree/templates/pagetree/test_page.html
@@ -2,13 +2,17 @@
 
 {% block js %}
 {% for pageblock in section.pageblock_set.all %}
+{% with block=pageblock %}
 {% renderjs pageblock %}
+{% endwith %}
 {% endfor %}
 {% endblock %}
 
 {% block css %}
 {% for pageblock in section.pageblock_set.all %}
+{% with block=pageblock %}
 {% rendercss pageblock %}
+{% endwith %}
 {% endfor %}
 {% endblock %}
 
@@ -56,10 +60,12 @@
 
 
 {% for pageblock in section.pageblock_set.all %}
+{% with block=pageblock %}
 <div class="pageblock{% if pageblock.css_extra %} {{pageblock.css_extra}}{% endif %}">
 {% if pageblock.label %}<h3>{{pageblock.label}}</h3>{% endif %}
 {% render block %}
 </div>
+{% endwith %}
 {% endfor %}
 
 

--- a/pagetree/templates/pagetree/test_page.html
+++ b/pagetree/templates/pagetree/test_page.html
@@ -1,14 +1,14 @@
 {% load render %}
 
 {% block js %}
-{% for block in section.pageblock_set.all %}
-{% renderjs block %}
+{% for pageblock in section.pageblock_set.all %}
+{% renderjs pageblock %}
 {% endfor %}
 {% endblock %}
 
 {% block css %}
-{% for block in section.pageblock_set.all %}
-{% rendercss block %}
+{% for pageblock in section.pageblock_set.all %}
+{% rendercss pageblock %}
 {% endfor %}
 {% endblock %}
 
@@ -55,9 +55,9 @@
 {% endif %}
 
 
-{% for block in section.pageblock_set.all %}
-<div class="pageblock{% if block.css_extra %} {{block.css_extra}}{% endif %}">
-{% if block.label %}<h3>{{block.label}}</h3>{% endif %}
+{% for pageblock in section.pageblock_set.all %}
+<div class="pageblock{% if pageblock.css_extra %} {{pageblock.css_extra}}{% endif %}">
+{% if pageblock.label %}<h3>{{pageblock.label}}</h3>{% endif %}
 {% render block %}
 </div>
 {% endfor %}

--- a/pagetree/templates/pagetree/testblock.html
+++ b/pagetree/templates/pagetree/testblock.html
@@ -1,2 +1,2 @@
 {% load markup %}
-{{block.body|markdown}}
+{{pageblock.body|markdown}}


### PR DESCRIPTION
Because 'block' has the potential to conflict with django's 'block'
templatetag.

Closes github issue #29