### PR TITLE
Add requirements.txt to fix readthedocs build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# Used by readthedocs.org to build the documentation
+Django>=1.8.0,<1.9.0


### PR DESCRIPTION
The documentation build has been failing with the error:

    ImportError: No module named django.conf

because django isn't installed when the documentation is built,
and I have 'autodoc' enabled to automatically read in the documentation
from the code.

https://readthedocs.org/projects/django-pagetree/builds/3236992/

By default, readthedocs uses `requirements.txt` to install dependencies,
so this should fix the error.