### PR TITLE
Remove notes on django 1.7 / south

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,3 @@ as possible.
 
 Documentation for pagetree is on
 [readthedocs](https://django-pagetree.readthedocs.org).
-
-## Note on South and Django 1.7
-
-1.0.0+ supports both South migrations and Django 1.7's built-in
-migrations. If you are using Django 1.7+, everything should just
-work. Dont' worry about it. If you are still on Django <1.7 and using
-South, you *will* need to upgrade to South 1.0+.
-
-Support for Django <1.7 and South will be dropped with version 2.0.0.


### PR DESCRIPTION
This is no longer relevant since django 1.7 and south aren't supported anymore