### PR TITLE
remove --use-mirrors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ env:
 
 # command to install dependencies
 install:
-  - pip install -q $DJANGO --use-mirrors
-  - pip install -q -r test_reqs.txt --use-mirrors
+  - pip install -q $DJANGO
+  - pip install -q -r test_reqs.txt
 
 # command to run tests
 script:


### PR DESCRIPTION
This option was removed in pip 7.0.0 - https://pip.pypa.io/en/stable/news/