### PR TITLE
Switch to django-bootstrap3 form rendering

### DIFF
--- a/pagetree/templates/pagetree/clone_hierarchy.html
+++ b/pagetree/templates/pagetree/clone_hierarchy.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load bootstrap %}
+{% load bootstrap3 %}
 {% load render %}
 {% block title %}{{hierarchy.label}} (clone){% endblock %}
 
@@ -22,7 +22,7 @@
        <form action="{% url 'clone-hierarchy' hierarchy.id %}"
         method="post" class="form-inline">
             {% csrf_token %}
-            {{form|bootstrap }}
+            {% bootstrap_form form %}
             <input type="submit" value="clone" class="btn btn-primary" />
         </form>
     </div>

--- a/pagetree/templates/pagetree/edit_page.html
+++ b/pagetree/templates/pagetree/edit_page.html
@@ -1,5 +1,5 @@
 {% extends "pagetree/base_pagetree.html" %}
-{% load bootstrap %}
+{% load bootstrap3 %}
 {% load render %}
 {% load static from staticfiles %}
 
@@ -246,9 +246,9 @@
                           {% endif %}>
                         {% csrf_token %}
 
-                        {{ pageblock.default_edit_form|bootstrap }}
+                        {% bootstrap_form pageblock.default_edit_form %}
                         {% with pageblock.edit_form as ef %}
-                        {{ ef|bootstrap }}
+                        {% bootstrap_form ef %}
                         {% if ef.alt_text %}
                         <div>{{ ef.alt_text|safe }}</div>
                         {% endif %}
@@ -294,7 +294,7 @@
           class="well form-inline">
         {% csrf_token %}
 
-        {{ section.add_child_section_form|bootstrap }}
+        {% bootstrap_form section.add_child_section_form %}
 
         <input type="submit" value="add child section" class="btn btn-primary"
                />
@@ -332,8 +332,8 @@
                         <fieldset>
                             <input type="hidden" name="blocktype" value="{{blocktype.display_name}}"/>
 
-                            {{section.add_pageblock_form|bootstrap}}
-                            {{blocktype.add_form|bootstrap}}
+                            {% bootstrap_form section.add_pageblock_form %}
+                            {% bootstrap_form blocktype.add_form %}
 
                         </fieldset>
 
@@ -358,7 +358,7 @@
           class="form-horizontal well">{% csrf_token %}
         <fieldset><legend>Edit Page</legend>
 
-            {{ section.edit_form|bootstrap }}
+            {% bootstrap_form section.edit_form %}
 
             <input type="submit" value="save" class="btn btn-primary" />
         </fieldset>

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         "Markdown",
         "coverage",
         "django-markwhat",
-        "django-bootstrap-form",
+        "django-bootstrap3",
         ],
     scripts=[],
     license="BSD",


### PR DESCRIPTION
We're using django-bootstrap3 on all our projects that use bootstrap,
so it's simpler to use its form renderer.