### PR TITLE
Add error messaging when user tries to create a duplicate hierarchy

### DIFF
--- a/pagetree/forms.py
+++ b/pagetree/forms.py
@@ -8,6 +8,21 @@ class CloneHierarchyForm(forms.ModelForm):
         model = Hierarchy
         fields = ['name', 'base_url']
 
+    def clean(self):
+        cleaned_data = super(CloneHierarchyForm, self).clean()
+        name = cleaned_data.get('name')
+        base_url = cleaned_data.get('base_url')
+
+        if Hierarchy.objects.filter(name=name).count() > 0:
+            raise forms.ValidationError(
+                'There\'s already a hierarchy with the name: {}'.format(
+                    name))
+
+        if Hierarchy.objects.filter(base_url=base_url).count() > 0:
+            raise forms.ValidationError(
+                'There\'s already a hierarchy with the base_url: {}'.format(
+                    base_url))
+
 
 MoveSectionForm = movenodeform_factory(
     Section,

--- a/pagetree/tests/test_forms.py
+++ b/pagetree/tests/test_forms.py
@@ -1,0 +1,47 @@
+from django.test import TestCase
+from pagetree.forms import CloneHierarchyForm
+from .factories import HierarchyFactory
+
+
+class CloneHierarchyFormTest(TestCase):
+    def test_init(self):
+        h = HierarchyFactory()
+        CloneHierarchyForm(instance=h)
+
+    def test_clean(self):
+        h = HierarchyFactory()
+        f = CloneHierarchyForm({
+            'name': 'new name',
+            'base_url': 'new',
+        },
+                               instance=h)
+        self.assertTrue(f.is_valid())
+        new_hier = f.save()
+        self.assertEqual(new_hier.name, 'new name')
+        self.assertEqual(new_hier.base_url, 'new')
+
+    def test_clean_prevents_duplicate_name(self):
+        h = HierarchyFactory()
+        f = CloneHierarchyForm({
+            'name': h.name,
+            'base_url': 'new',
+        },
+                               instance=h)
+        self.assertFalse(f.is_valid())
+        self.assertEqual(f.errors, {
+            '__all__': [
+                u"There's already a hierarchy with the name: main"]
+        })
+
+    def test_clean_prevents_duplicate_base_url(self):
+        h = HierarchyFactory()
+        f = CloneHierarchyForm({
+            'name': 'new name',
+            'base_url': h.base_url,
+        },
+                               instance=h)
+        self.assertFalse(f.is_valid())
+        self.assertEqual(f.errors, {
+            '__all__': [
+                u"There's already a hierarchy with the base_url: /pages/"]
+        })


### PR DESCRIPTION
Helps address issue #120