### PR TITLE
return cleaned_data when done validating

### DIFF
--- a/pagetree/forms.py
+++ b/pagetree/forms.py
@@ -23,6 +23,8 @@ class CloneHierarchyForm(forms.ModelForm):
                 'There\'s already a hierarchy with the base_url: {}'.format(
                     base_url))
 
+        return cleaned_data
+
 
 MoveSectionForm = movenodeform_factory(
     Section,


### PR DESCRIPTION
This allows inheriting forms to also use the clean() method in the documented way, without having to look at self.cleaned_data