### PR TITLE
make label/css_extra not required on add form

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+* label/css_extra required field bugfix on add pageblock form
+
 1.1.14 (2016-03-31)
 ===================
 

--- a/pagetree/models.py
+++ b/pagetree/models.py
@@ -409,11 +409,13 @@ class Section(MP_Node):
 
         class AddPageBlockForm(forms.Form):
             label = forms.CharField(
+                required=False,
                 widget=forms.TextInput(
                     attrs={'id': 'id_label_%d' % unique_id}
                 ))
             css_extra = forms.CharField(
                 label='extra CSS classes',
+                required=False,
                 widget=forms.TextInput(
                     attrs={'id': 'id_css_extra_%d' % unique_id}
                 ))

--- a/pagetree/tests/test_models.py
+++ b/pagetree/tests/test_models.py
@@ -178,6 +178,8 @@ class OneLevelDeepTest(unittest.TestCase):
         self.assertEqual(
             'css_extra' in f.fields,
             True)
+        self.assertFalse(f.fields['label'].required)
+        self.assertFalse(f.fields['css_extra'].required)
 
     def test_valid_path(self):
         self.assertEqual(self.h.find_section_from_path("section-1/"),


### PR DESCRIPTION
Those fields shouldn't be required anywhere.