### PR TITLE
migration to delete TestBlock table if it exists

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+* migration to delete `TestBlock` if it exists (cleaning up an earlier
+  migration snafu)
+
 1.2.0 (2016-05-27)
 ===================
 * Added jshint/jscs checks

--- a/pagetree/migrations/0002_delete_testblock.py
+++ b/pagetree/migrations/0002_delete_testblock.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+from django.db import migrations
+
+
+class ConditionalDeleteModel(migrations.DeleteModel):
+    def database_forwards(self, app_label, schema_editor, from_state,
+                          to_state):
+        try:
+            super(ConditionalDeleteModel, self).database_forwards(
+                self, app_label, schema_editor, from_state, to_state)
+        except:
+            """ if it fails, it's totally fine. it just means that the
+            table we wanted to delete doesn't exist. so we ignore it.
+
+            it would be nice to catch a more specific exception, but
+            different databases raise different ones..."""
+            pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pagetree', '0001_initial'),
+    ]
+
+    operations = [
+        ConditionalDeleteModel(
+            name='TestBlock',
+        ),
+    ]


### PR DESCRIPTION
At one point in the past, the `TestBlock` model was visible to the
migration system and a bunch of our apps have a stray
`pagetree_testblock` table in the database. When `manage.py migrate` is
run against those databases, we get:

```
  Your models have changes that are not yet reflected in a migration, and so won't be applied.
  Run 'manage.py makemigrations' to make new migrations, and then re-run 'manage.py migrate' to apply them.
```

Running `manage.py makemigrations` will create a pagetree migration that
deletes the table.

Unfortunately, if that gets checked in, it breaks the apps that managed
to avoid getting that `pagetree_testblock` table created in the first
place (it tries to delete a table that doesn't exist and that fails).

Even more importantly, it breaks the unit tests since the in-memory
database doesn't have that table.

This commit adds a migration which does the
`migrations.DeleteModel(name="TestBlock")`, but wraps it in a try/catch
so it's harmless if the table doesn't actually exist.