### PR TITLE
Fix a cache clear after a return statement

### DIFF
--- a/pagetree/models.py
+++ b/pagetree/models.py
@@ -608,8 +608,8 @@ class Section(MP_Node):
             data=json,
             activity=activity,
             comment=comment)
-        return v
         self.clear_tree_cache()
+        return v
 
     def gate_check(self, user):
         """ return bool, section tuple for whether the user


### PR DESCRIPTION
This otherwise wouldn't get executed - I'm surprised flake8 didn't catch
it.