### PR TITLE
Add custom cache clear option

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,0 +1,9 @@
+Configuration
+=============
+
+.. configuration::
+
+`PAGETREE_CUSTOM_CACHE_CLEAR`
+    Use this as a hook to clear any custom caches you've set up. It will
+    get called whenever Pagetree's internal cache is called. The function
+    should take one argument: the `Section` whose cache is getting cleared.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,7 @@ as possible.
    :maxdepth: 2
 
    installation
+   configuration
    custom_pageblocks
    api
    testing

--- a/pagetree/models.py
+++ b/pagetree/models.py
@@ -193,6 +193,10 @@ class Section(MP_Node):
         cache.delete("pagetree.%d.is_last_child" % self.id)
         cache.delete("pagetree.%d.get_edit_url" % self.id)
 
+        if hasattr(settings, 'PAGETREE_CUSTOM_CACHE_CLEAR') and \
+           callable(settings.PAGETREE_CUSTOM_CACHE_CLEAR):
+            settings.PAGETREE_CUSTOM_CACHE_CLEAR(self)
+
     def clear_tree_cache(self):
         depth_first_traversal = self.get_root().get_annotated_list()
         for (s, ai) in depth_first_traversal:


### PR DESCRIPTION
I've added some caching to some of UELC's db-intensive functions,
reducing queries on the facilitator page:
  https://github.com/ccnmtl/uelc/tree/uelchandler-caching

This requires a hook for custom cache clearing when the tree is changed,
so we don't present the user with outdated data.

This is related to PMT #107228