### PR TITLE
Html5 validation

### DIFF
--- a/pagetree/models.py
+++ b/pagetree/models.py
@@ -355,7 +355,8 @@ class Section(MP_Node):
             i += 1
 
     def edit_form(self):
-        TRUE_FALSE=((True, 'Yes'), (False, 'No'))
+        TRUE_FALSE = ((True, 'Yes'), (False, 'No'))
+
         class EditSectionForm(forms.Form):
             label = forms.CharField(initial=self.label)
             slug = forms.CharField(initial=self.slug)

--- a/pagetree/models.py
+++ b/pagetree/models.py
@@ -361,14 +361,12 @@ class Section(MP_Node):
             slug = forms.CharField(initial=self.slug)
             show_toc = forms.BooleanField(
                 initial=self.show_toc,
-                required=False,
                 widget=forms.RadioSelect(choices=TRUE_FALSE),
                 label="Show Table of Contents",
                 help_text=("list table of contents of "
                            "immediate child sections (if applicable)"))
             deep_toc = forms.BooleanField(
                 initial=self.deep_toc,
-                required=False,
                 widget=forms.RadioSelect(choices=TRUE_FALSE),
                 label="Show Deep Table of Contents",
                 help_text=(

--- a/pagetree/models.py
+++ b/pagetree/models.py
@@ -355,20 +355,18 @@ class Section(MP_Node):
             i += 1
 
     def edit_form(self):
-        TRUE_FALSE = ((True, 'Yes'), (False, 'No'))
-
         class EditSectionForm(forms.Form):
             label = forms.CharField(initial=self.label)
             slug = forms.CharField(initial=self.slug)
             show_toc = forms.BooleanField(
                 initial=self.show_toc,
-                widget=forms.RadioSelect(choices=TRUE_FALSE),
+                required=False,
                 label="Show Table of Contents",
                 help_text=("list table of contents of "
                            "immediate child sections (if applicable)"))
             deep_toc = forms.BooleanField(
                 initial=self.deep_toc,
-                widget=forms.RadioSelect(choices=TRUE_FALSE),
+                required=False,
                 label="Show Deep Table of Contents",
                 help_text=(
                     "include children of children (etc) in TOC. "

--- a/pagetree/models.py
+++ b/pagetree/models.py
@@ -355,16 +355,21 @@ class Section(MP_Node):
             i += 1
 
     def edit_form(self):
+        TRUE_FALSE=((True, 'Yes'), (False, 'No'))
         class EditSectionForm(forms.Form):
             label = forms.CharField(initial=self.label)
             slug = forms.CharField(initial=self.slug)
             show_toc = forms.BooleanField(
                 initial=self.show_toc,
+                required=False,
+                widget=forms.RadioSelect(choices=TRUE_FALSE),
                 label="Show Table of Contents",
                 help_text=("list table of contents of "
                            "immediate child sections (if applicable)"))
             deep_toc = forms.BooleanField(
                 initial=self.deep_toc,
+                required=False,
+                widget=forms.RadioSelect(choices=TRUE_FALSE),
                 label="Show Deep Table of Contents",
                 help_text=(
                     "include children of children (etc) in TOC. "

--- a/pagetree/views.py
+++ b/pagetree/views.py
@@ -102,8 +102,13 @@ def edit_section(request, section_id, success_url=None):
     section.save_version(request.user, activity="edit section")
     section.label = request.POST.get('label', '')
     section.slug = slugify(request.POST.get('slug', section.label))[:50]
-    section.show_toc = request.POST.get('show_toc', False)
-    section.deep_toc = request.POST.get('deep_toc', False)
+
+    value = request.POST.get('show_toc', False)
+    section.show_toc = value in ('True', True, 'on')
+
+    value = request.POST.get('deep_toc', False)
+    section.deep_toc = value in ('True', True, 'on')
+
     section.save()
     section.enforce_slug()
     section.save()


### PR DESCRIPTION
This PR switches the show_toc and deep_toc fields to render as radio buttons with explicit true/false values. This change resolves two issues:

1. The "required" attribute on the `show_toc` and `deep_toc` checkbox fields was triggering [HTML5 validation rules](https://www.w3.org/WAI/tutorials/forms/validation/#validating-required-input). This validation was preventing users from submitting the form unless these fields were checked. Though these are required database fields, a valid value is False. (Note: adding a "required=False" to the BooleanField would've resolved #1, but not #2.)

2. The checkbox fields were returning "on" as a checked value, as the Bootstrap renderer was not setting the value attribute. The view code is (rightly) expecting a boolean field, and was blowing up.

Switching over to radio buttons ensured a valid boolean value displayed at all times.