### PR TITLE
Remove django 1.9 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
   - '3.5'
 env:
   - DJANGO="Django>=1.8.0,<1.9.0"
-  - DJANGO="Django>=1.9.0,<1.10.0"
   - DJANGO="Django>=1.10,<1.11.0"
   - DJANGO="Django>=1.11,<1.12.0"
 install:


### PR DESCRIPTION
All apps are off django 1.9: https://pmt.ccnmtl.columbia.edu/milestone/4773/

(mediathread is still on 1.8, and doesn't use pagetree)