### PR TITLE
Remove MIDDLEWARE_CLASSES in test runner

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -21,12 +21,6 @@ def main():
             'django.contrib.auth.middleware.AuthenticationMiddleware',
             'django.contrib.messages.middleware.MessageMiddleware',
         ),
-        # For django 1.8
-        MIDDLEWARE_CLASSES=(
-            'django.contrib.sessions.middleware.SessionMiddleware',
-            'django.contrib.auth.middleware.AuthenticationMiddleware',
-            'django.contrib.messages.middleware.MessageMiddleware',
-        ),
         TEMPLATES=[
             {
                 'BACKEND': 'django.template.backends.django.DjangoTemplates',


### PR DESCRIPTION
This was only needed for Django 1.8.