### PR TITLE
Update contact email, remove setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     name="django-pagetree",
     version="1.4.1",
     author="Anders Pearson",
-    author_email="ccnmtl-dev@columbia.edu",
+    author_email="ctl-dev@columbia.edu",
     url="https://github.com/ccnmtl/django-pagetree",
     description="Tree of Pages helper application",
     long_description="Application for managing trees of pages",


### PR DESCRIPTION
We build packages as python3-only now, so we don't need to universal setting.