### PR TITLE
github actions: test on python 3.13 as well

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-          python-version: ["3.12"]
+          python-version: ["3.12", "3.13"]
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
Ubuntu 26.04 will be using python 3.13