### PR TITLE
Remove dependency on six

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,7 @@
 * Bootstrap style fix for pageblock modals
 * Introduced BasePageBlock.form attribute, which is now needed when
   implementing this abstract base class.
+* Removed dependency on `six`
 
 1.6.4 (2026-03-25)
 ==================

--- a/pagetree/reports.py
+++ b/pagetree/reports.py
@@ -1,15 +1,13 @@
 from __future__ import unicode_literals
 
 import abc
-from six import add_metaclass
 
 from django.contrib.auth.models import User
 from django.apps import apps
 from django.contrib.contenttypes.models import ContentType
 
 
-@add_metaclass(abc.ABCMeta)
-class ReportableInterface(object):
+class ReportableInterface(metaclass=abc.ABCMeta):
     """ Abstract base class for a reportable interface that can be added to
         a given pageblock to support dynamic discovery of reporting data
 
@@ -33,8 +31,7 @@ class ReportableInterface(object):
         return
 
 
-@add_metaclass(abc.ABCMeta)
-class ReportColumnInterface(object):
+class ReportColumnInterface(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def identifier(self):

--- a/pagetree/templatetags/render.py
+++ b/pagetree/templatetags/render.py
@@ -10,8 +10,6 @@ and have block.render() get called with the existing
 request context passed through
 
 """
-
-from six import string_types
 from django import template
 
 register = template.Library()
@@ -28,7 +26,7 @@ class BaseNode(template.Node):
             context_dict.update(d)
         # can only take string keys
         for k in context_dict.keys():
-            if not isinstance(k, string_types):
+            if not isinstance(k, str):
                 del context_dict[k]
         return b, context_dict
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
         "Django",
         "django-treebeard",
         "django-bootstrap5",
-        "six",
         "Markdown",
         "django-markdownify",
         ],

--- a/test_reqs.txt
+++ b/test_reqs.txt
@@ -8,7 +8,6 @@ pep8==1.7.1
 pyflakes==3.4.0
 Faker==40.13.0
 factory_boy==3.3.3
-six==1.17.0
 pycodestyle==2.14.0
 mccabe==0.7.0
 python-dateutil==2.9.0.post0


### PR DESCRIPTION
This library was only relevant for python 2 and 3 compatibility, and is no longer needed.