### PR TITLE
BasePageBlock.edit_form: call self.form()

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+1.7.1
+==================
+* BasePageBlock.edit_form() fix
+
 1.7.0 (2026-04-17)
 ==================
 * Bootstrap style fix for pageblock modals

--- a/pagetree/generic/models.py
+++ b/pagetree/generic/models.py
@@ -111,7 +111,7 @@ class BasePageBlock(models.Model):
         return self.form()
 
     def edit_form(self):
-        return BasePageBlockForm(instance=self)
+        return self.form(instance=self)
 
     @staticmethod
     def create(request):


### PR DESCRIPTION
I missed this method before making the 1.7.0 release.