### PR TITLE
Fix duplicate root section bug - sentry error ABSI-S

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 1.7.2
 ==================
 * Use Django's new LoginRequiredMixin for EditView and InstructorView.
+* Fix query for Hierarchy.get_root() to fix an edge-case bug
 
 1.7.1 (2026-04-17)
 ==================

--- a/pagetree/models.py
+++ b/pagetree/models.py
@@ -48,13 +48,14 @@ class Hierarchy(models.Model):
     def __str__(self):
         return self.name
 
-    def get_root(self):
+    def get_root(self) -> 'Section':
         # will create it if it doesn't exist
         try:
-            return Section.objects.get(hierarchy=self,
-                                       label="Root").get_root()
+            root_section = Section.objects.get(
+                hierarchy=self, label='Root', slug='')
+            return root_section.get_root()
         except Section.DoesNotExist:
-            return Section.add_root(label="Root", slug="", hierarchy=self)
+            return Section.add_root(hierarchy=self, label='Root', slug='')
 
     def get_top_level(self):
         return self.get_root().get_children()

--- a/pagetree/tests/test_models.py
+++ b/pagetree/tests/test_models.py
@@ -157,6 +157,7 @@ class OneLevelDeepTest(TestCase):
                 'pageblocks': [],
                 'children': [],
             })
+
         r = self.root.get_children()
         self.section1 = r[0]
         self.section2 = r[1]
@@ -847,3 +848,53 @@ class UserPageVisitTest(TestCase):
     def test_is_valid_from_factory(self):
         upv = UserPageVisitFactory()
         upv.full_clean()
+
+
+class RootTest(TestCase):
+    def setUp(self):
+        self.h = Hierarchy.objects.create(name='main', base_url='')
+        self.root = self.h.get_root()
+        self.root.add_child_section_from_dict(
+            {
+                'label': 'Section 1',
+                'slug': 'section-1',
+                'pageblocks': [],
+                'children': [],
+            })
+        self.root.add_child_section_from_dict(
+            {
+                'label': 'Section 2',
+                'slug': 'section-2',
+                'pageblocks': [],
+                'children': [],
+            })
+        self.root.add_child_section_from_dict(
+            {
+                'label': 'Section 3',
+                'slug': 'section-3',
+                'pageblocks': [],
+                'children': [],
+            })
+
+        # Test that using a Section with label: Root doesn't break
+        # Hierarchy.get_root()
+        self.root.add_child_section_from_dict(
+            {
+                'label': 'Root',
+                'slug': 'root',
+                'pageblocks': [],
+                'children': [],
+            })
+
+        r = self.root.get_children()
+        self.section1 = r[0]
+        self.section2 = r[1]
+        self.section3 = r[2]
+
+    def tearDown(self):
+        self.h.delete()
+
+    def test_root(self):
+        self.assertEqual(
+            self.h.get_root().id,
+            self.root.id)


### PR DESCRIPTION
This fixes an edge-case bug that can be reproduced by making a Section with label set to "Root". Pagetree keeps an internal "Root" Section with slug set to '', and uses this in the get_root() query here. This makes the query more specific to address this issue, and adds a test for this case.