### PR TITLE
toc.html: Avoid duplicate call to Section.get_children()

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+1.7.11
+===================
+* toc.html: Avoid duplicate call to s.get_children()
+
 1.7.10 (2026-06-12)
 ===================
 * Edit page view: Add separator dot to make pagination more clear.

--- a/pagetree/templates/pagetree/toc.html
+++ b/pagetree/templates/pagetree/toc.html
@@ -7,21 +7,25 @@
 <ul class="toc">
 {% for s in section.get_descendants %}
 <li class="menu-{{s.depth}}">
-  <a href="{{s.get_absolute_url}}">{{s.label}}</a>
-  {% if s.get_children %}
-     <ul id="section-ul-{{s.id}}">
-  {% else %}
-     {% if s.is_last_child %}
-       {% for lc in s.closing_children %}
-         </ul>
-       {% endfor %}
-     {% endif %}
-  {% endif %}
+    <a href="{{s.get_absolute_url}}">{{s.label}}</a>
 
-  {% if s.get_children %}
-  {% else %}
-    </li>
-  {% endif %}
+    {% with s_children=s.get_children %}
+        {% if s_children %}
+        <ul id="section-ul-{{s.id}}">
+        {% else %}
+            {% if s.is_last_child %}
+            {% for lc in s.closing_children %}
+                </ul>
+            {% endfor %}
+            {% endif %}
+
+        {% endif %}
+
+        {% if not s_children %}
+            </li>
+        {% endif %}
+    {% endwith %}
+
 {% endfor %}
 </ul>
 


### PR DESCRIPTION
A lot of this logic in the template here should really be in python for further optimization, but this is a small improvement for now.