### PR TITLE
Edit Page button: Remove unnecessary styling and only show for staff

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+1.7.15
+===================
+* "edit page" button: Remove unnecessary styling, and only show for staff.
+
 1.7.14 (2026-07-01)
 ===================
 * Use modal-lg for large bootstrap modals.

--- a/pagetree/templates/pagetree/page.html
+++ b/pagetree/templates/pagetree/page.html
@@ -66,8 +66,8 @@
 {% endblock %}
 
 {% block navrightextra %}
-{% if not request.user.is_anonymous %}
-<a href="{{section.get_edit_url}}" class="btn btn-success mt-2 float-end">edit page</a>
+{% if request.user.is_staff %}
+<a href="{{section.get_edit_url}}" class="btn btn-success">edit page</a>
 {% endif %}
 {% endblock %}
 

--- a/pagetree/templates/pagetree/test_page.html
+++ b/pagetree/templates/pagetree/test_page.html
@@ -35,8 +35,8 @@
 {% endblock %}
 
 {% block navrightextra %}
-{% if not request.user.is_anonymous %}
-<li><a href="{{section.get_edit_url}}" class="btn btn-success mt-2 float-end">edit page</a></li>
+{% if request.user.is_staff %}
+<li><a href="{{section.get_edit_url}}" class="btn btn-success">edit page</a></li>
 {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
The float styling here can be problematic and can be left up to the application including this button via the navrightextra block.

Also, I'm not sure why this button was being shown for all non-anonymous users. This should be shown to staff users.